### PR TITLE
Reduce max-width of ellipsis in navbar to make room for one more item

### DIFF
--- a/less/navbar.less
+++ b/less/navbar.less
@@ -810,13 +810,13 @@
 
     .text-ellipses,
     .text-ellipsis {
-        max-width: 75px;
+        max-width: 5px;
         display: inline-block;
     }
     @media (min-width: @screen-lg-min) {
         .text-ellipses,
         .text-ellipsis {
-            max-width: 125px;
+            max-width: 30px;
         }
     }
     @media (min-width: @screen-xl-min) {


### PR DESCRIPTION
<img width="762" alt="my_balances" src="https://cloud.githubusercontent.com/assets/6596835/20225612/32c810aa-a83c-11e6-83c5-918fc2b10861.png">


And for `@media (min-width: @screen-lg-min)`

<img width="1059" alt="my_balances" src="https://cloud.githubusercontent.com/assets/6596835/20225623/4292b10c-a83c-11e6-8bbc-83db702c3883.png">
