### PR TITLE
Fix for strong tag styles in active item in dropdown menu

### DIFF
--- a/docs/_includes/components/dropdowns.html
+++ b/docs/_includes/components/dropdowns.html
@@ -44,7 +44,7 @@
       </button>
       <ul class="dropdown-menu" role="menu" aria-labelledby="dropdownMenu2">
         <li role="presentation"><a role="menuitem" tabindex="-1" href="#">Action</a></li>
-        <li role="presentation"><a role="menuitem" tabindex="-1" href="#">Another action</a></li>
+        <li class="active" role="presentation"><a role="menuitem" tabindex="-1" href="#"><strong>Another</strong> action</a></li>
         <li role="presentation"><a role="menuitem" tabindex="-1" href="#">Something else here</a></li>
       </ul>
     </div>

--- a/less/dropdowns.less
+++ b/less/dropdowns.less
@@ -123,6 +123,10 @@
     outline: 0;
     background-color: @dropdown-link-active-bg;
   }
+
+  strong {
+    color: inherit;
+  }
 }
 
 // Disabled state


### PR DESCRIPTION
Previously strong was styled with a default color that blended with
active item background color. Not anymore.