### PR TITLE
Revert version bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bootstrap",
-  "version": "5.18.16",
+  "version": "5.18.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bootstrap",
   "description": "The most popular front-end framework for developing responsive, mobile first projects on the web.",
-  "version": "5.18.16",
+  "version": "5.18.15",
   "keywords": [
     "css",
     "less",


### PR DESCRIPTION
Installing the latest release from bootstrap was failing due the inconsistency between version in package.json and the last released version.