### PR TITLE
feat: add cookie consent mechanism to header

### DIFF
--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -49,6 +49,8 @@
 <link rel="apple-touch-icon" href="/apple-touch-icon.png">
 <link rel="icon" href="/favicon.ico">
 
+<script type="application/javascript" src="https://transferwise.com/cookie-consent.js"></script>
+
 <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),


### PR DESCRIPTION
To make the tw boostrap website ICO compliant, add the  cookie consent  mechanism script to the header.

